### PR TITLE
fixed deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # this is after the build succeeds
-git cd build
+cd build
 git init
 git checkout --orphan gh-pages
     git remote add upstream https://$GH_TOKEN@github.com/brngdsn/thntctn0


### PR DESCRIPTION
accidentally tried to `$ git cd build` instead of `$ cd build`
